### PR TITLE
feat: add option to skip invalid tags in versioning workflow

### DIFF
--- a/.github/workflows/versioning.yml
+++ b/.github/workflows/versioning.yml
@@ -78,6 +78,7 @@ jobs:
           minorList: ${{ github.event.inputs.minorList || 'FEATURE, Feature, feature, FEAT, Feat, feat' }}
           patchList: ${{ github.event.inputs.patchList || 'FIX, Fix, fix, FIXED, Fixed, fixed, Refactor, Refact, Refac, refac, refact, refactor, REFAC, REFACT, REFACTOR, refacs, refacts, refactors, REFACS, REFACTS, REFACTORS, config, conf, configs, confs, cofiguration, cofigurations, configure, doc, docs, docu, document, documentation, dependencies, dependencie, depends, depend, deps, dep, chore, build, rebuild, build(deps), build(deps-dev), ci, CI, test, tests, testing, wip, WIP, Wip' }}
           patchAll: false
+          skipInvalidTags: true
 
       - name: Scan versioning sources
         id: scan


### PR DESCRIPTION
Action ignora los tags invalidos (o tags candidatas) cuando trata de calcular la siguiente version de `main`