### PR TITLE
fix: busca version.txt y package.json en cualquier carpeta del repo

### DIFF
--- a/.github/workflows/versioning.yml
+++ b/.github/workflows/versioning.yml
@@ -89,14 +89,14 @@ jobs:
           #!/bin/bash
 
           # Eval if exists a version.txt file to update, store true or false
-          if [ -f "version.txt" ]; then
+          if [ -n "$(find . -name 'version.txt')" ]; then
             updateVersionTxt="true"
           else
             updateVersionTxt="false"
           fi
 
           # Find the package.json file
-          if [ -f "package.json" ]; then
+          if [ -n "$(find . -name 'package.json')" ]; then
             updatePackageJson="true"
           else
             updatePackageJson="false"


### PR DESCRIPTION
Agrego soporte para que busque los archivos `version.txt` y `package.json` en cualquier parte del repo.

> [!IMPORTANT]
> Esto sigue soportanto un unico archivo `version.txt` y un unico archivo `package.json` por repositorio. A diferencia de los archivos `*.csproj` que se versionan todas las coincidencias.
